### PR TITLE
Support insim version 9

### DIFF
--- a/src/clj_insim/client.clj
+++ b/src/clj_insim/client.clj
@@ -90,6 +90,7 @@
            to-lfs (a/chan (a/sliding-buffer 10))
            running? (atom true)
            new-byte-size? (> (:body/insim-version isi) 8)]
+       (println "clj-insim: using INSIM_VERSION: " (:body/insim-version isi))
        (a/go
          (a/>!! to-lfs isi)
          (while @running?

--- a/src/clj_insim/client.clj
+++ b/src/clj_insim/client.clj
@@ -90,7 +90,7 @@
            to-lfs (a/chan (a/sliding-buffer 10))
            running? (atom true)
            new-byte-size? (> (:body/insim-version isi) 8)]
-       (println "clj-insim: using INSIM_VERSION: " (:body/insim-version isi))
+       (println "clj-insim: using INSIM_VERSION:" (:body/insim-version isi))
        (a/go
          (a/>!! to-lfs isi)
          (while @running?

--- a/src/clj_insim/client.clj
+++ b/src/clj_insim/client.clj
@@ -88,7 +88,8 @@
            output-stream (io/output-stream socket)
            from-lfs (a/chan (a/sliding-buffer 10))
            to-lfs (a/chan (a/sliding-buffer 10))
-           running? (atom true)]
+           running? (atom true)
+           new-byte-size? (> (:body/insim-version isi) 8)]
        (a/go
          (a/>!! to-lfs isi)
          (while @running?
@@ -96,7 +97,7 @@
              (wrap-try-catch write/instruction output-stream packet))))
        (a/go
          (while @running?
-           (when-let [packet (wrap-try-catch read/packet input-stream)]
+           (when-let [packet (wrap-try-catch (read/packet new-byte-size?) input-stream)]
              (dispatch {:to-lfs to-lfs} packet)
              (a/>! from-lfs packet))))
        (println "clj-insim: client started")

--- a/src/clj_insim/client.clj
+++ b/src/clj_insim/client.clj
@@ -94,7 +94,7 @@
          (a/>!! to-lfs isi)
          (while @running?
            (let [packet (a/<! to-lfs)]
-             (wrap-try-catch write/instruction output-stream packet))))
+             (wrap-try-catch (write/instruction new-byte-size?) output-stream packet))))
        (a/go
          (while @running?
            (when-let [packet (wrap-try-catch (read/packet new-byte-size?) input-stream)]

--- a/src/clj_insim/codecs.clj
+++ b/src/clj_insim/codecs.clj
@@ -223,6 +223,15 @@
       :body/num-stops m/ubyte
       :body/fuel-200 m/ubyte))
 
+   :mal
+   (fn [{:header/keys [data]}]
+     (let [num-mods data]
+       (m/struct
+        :body/ucid m/ubyte
+        :body/flags m/ubyte
+        :body/spare (m/ascii-string 2)
+        :body/skin-ids (m/array m/uint32 num-mods))))
+
    ;; TODO: Add MCI packet
 
    :msl

--- a/src/clj_insim/enum.clj
+++ b/src/clj_insim/enum.clj
@@ -12,7 +12,7 @@
    :mod :vtn :rst :ncn :cnl :cpr :npl :plp :pll :lap :spx :pit :psf :pla :cch
    :pen :toc :flg :pfl :fin :res :reo :nlp :mci :msx :msl :crs :bfn :axi :axo
    :btn :btc :btt :rip :ssh :con :obh :hlv :plc :axm :acr :hcp :nci :jrr :uco :oco
-   :ttc :slc :csc :cim])
+   :ttc :slc :csc :cim :mal])
 
 (def HOST [:guest :host])
 
@@ -45,7 +45,7 @@
 
 (def TINY_HEADER_DATA
   [:none :ver :close :ping :reply :vtc :scp :sst :gth :mpe :ism :ren :clr :ncn
-   :npl :res :nlp :mci :reo :rst :axi :axc :rip :nci :alc :axm :slc])
+   :npl :res :nlp :mci :reo :rst :axi :axc :rip :nci :alc :axm :slc :mal])
 
 (def TTC_HEADER_DATA [:none :sel :sel-start :sel-stop])
 

--- a/src/clj_insim/packets.clj
+++ b/src/clj_insim/packets.clj
@@ -59,7 +59,7 @@
       :or {admin "pwd"
            flags #{:con :hlv} ; Contact & Hot lap validity
            iname "clj-insim"
-           insim-version 8
+           insim-version 9
            interval 100
            prefix \!}}]
    ;; TODO: Implement is-flags

--- a/src/clj_insim/parse.clj
+++ b/src/clj_insim/parse.clj
@@ -63,6 +63,7 @@
    :crs data->player-id
    :hlv data->player-id
    :lap data->player-id
+   :mal {:header/data :header/num-mods}
    :ncn {:header/data :header/ucid}
    :npl data->player-id
    :pll data->player-id

--- a/src/clj_insim/parse.clj
+++ b/src/clj_insim/parse.clj
@@ -203,4 +203,8 @@
       (not (raw? header)) (update :header/type (enum/encode enum/HEADER_TYPE))
       (and (not (raw? header)) data-enum) (update :header/data (enum/encode data-enum)))))
 
-(def instruction (comp parse-instruction-header parse-instruction-body))
+(defn instruction [size-div packet]
+  (-> packet
+      parse-instruction-body
+      parse-instruction-header
+      (update :header/size (comp int #(/ % size-div)))))

--- a/src/clj_insim/read.clj
+++ b/src/clj_insim/read.clj
@@ -16,7 +16,7 @@
   "Read and parse header data from input-stream. Multiplies :header/size by
    size-mul on the fly."
   [size-mul input-stream]
-  (-> input-stream
+  (some-> input-stream
       read-header
       parse/header
       (update :header/size (comp int (partial * size-mul)))))

--- a/src/clj_insim/read.clj
+++ b/src/clj_insim/read.clj
@@ -2,18 +2,24 @@
   (:require [clj-insim.codecs :as codecs]
             [clj-insim.models.packet :as packet]
             [clj-insim.parse :as parse]
-            [clj-insim.utils :as u]
             [marshal.core :as m]))
 
 (defn- read-header
-  "Reads 4 bytes from input-stream and returns these, marhalled into a clojure
+  "Reads 4 bytes from input-stream and returns these, marshalled into a clojure
    map with the header codec. Returns false when no bytes are available to read."
   [input-stream]
   {:post [(or (nil? %) (packet/raw? %))]}
-  (and (when (pos? (.available input-stream)) true)
-       (m/read input-stream codecs/header)))
+  (when (pos? (.available input-stream))
+    (m/read input-stream codecs/header)))
 
-(def ^:private header (comp parse/header read-header))
+(defn- header
+  "Read and parse header data from input-stream. Multiplies :header/size by
+   size-mul on the fly."
+  [size-mul input-stream]
+  (-> input-stream
+      read-header
+      parse/header
+      (update :header/size (comp int (partial * size-mul)))))
 
 (defn- get-body-codec
   "Returns the marshal codec for a given header (type).
@@ -36,9 +42,13 @@
       (parse/body)))
 
 (defn packet
-  "Read (info) packet header and body from input-stream, parse and return it.
-   Returns `nil` when no data is present on the input-stream."
-  [input-stream]
-  {:post [(or (nil? %) (packet/parsed? %))]}
-  (when-let [hdr (header input-stream)]
-    (body input-stream hdr)))
+  "Returns a function that reads (info) packet header and body from input-stream,
+   parse and return it. The returned fn returns `nil` when no data is present on
+   the input-stream."
+  [new-byte-size?]
+  (let [header-fn (if new-byte-size? (partial header 4) (partial header 1))]
+    (fn read-packet
+      [input-stream]
+      {:post [(or (nil? %) (packet/parsed? %))]}
+      (when-let [hdr (header-fn input-stream)]
+        (body input-stream hdr)))))

--- a/src/examples/echo.clj
+++ b/src/examples/echo.clj
@@ -16,7 +16,7 @@
    console, and to LFS via a IS_MST packet. Well not ALL incoming packets, we
    ignore IS_MSO packets because this causes a feedback loop :-)."
   []
-  (let [client (client/start) ;; 1. Start the client
+  (let [client (client/start {:isi (packets/isi {:insim-version 9})}) ;; 1. Start the client
         stop #(client/stop client)] ;; 2. Define a function that terminates client.
   (client/go client dispatch) ;; 3. Start a go block with a while-loop to check for packets
   stop)) ;; 5. Expose the stop function so we can use it elsewhere.
@@ -29,5 +29,3 @@
   ;; To stop the client and echo process, simply call the stored function
   (echo-client)
 )
-
-

--- a/src/examples/echo.clj
+++ b/src/examples/echo.clj
@@ -16,7 +16,7 @@
    console, and to LFS via a IS_MST packet. Well not ALL incoming packets, we
    ignore IS_MSO packets because this causes a feedback loop :-)."
   []
-  (let [client (client/start {:isi (packets/isi {:insim-version 9})}) ;; 1. Start the client
+  (let [client (client/start) ;; 1. Start the client
         stop #(client/stop client)] ;; 2. Define a function that terminates client.
   (client/go client dispatch) ;; 3. Start a go block with a while-loop to check for packets
   stop)) ;; 5. Expose the stop function so we can use it elsewhere.

--- a/test/clj_insim/parse_test.clj
+++ b/test/clj_insim/parse_test.clj
@@ -22,7 +22,13 @@
 
 (deftest pipeline-test
   (testing "pipe instruction & header/body"
-    (let [packet (merge #:header{:size 4 :type :small :request-info 1 :data :ssp}
-                        #:body{:unsigned-value 500})]
-      (is (= packet
-             ((comp sut/body sut/header) (sut/instruction packet)))))))
+    (testing "with old byte size"
+      (let [packet (merge #:header{:size 8 :type :small :request-info 1 :data :ssp}
+                          #:body{:unsigned-value 500})]
+        (is (= packet
+               ((comp sut/body sut/header) (sut/instruction 1 packet))))))
+    (testing "with new byte size"
+      (let [packet (merge #:header{:size 8 :type :small :request-info 1 :data :ssp}
+                          #:body{:unsigned-value 500})]
+        (is (= (assoc packet :header/size 2)
+               ((comp sut/body sut/header) (sut/instruction 4 packet))))))))


### PR DESCRIPTION
Add support for insim version 9 (patch 0.7A).

If a client with insim-version 9 is started;
Packet size is now in multiples of 4. So whenever we read info packets, multiply header/size by 4. Whenever we write instruction packets, divide header/size by 4. This way we can keep using the old packet size inside clj-insim.